### PR TITLE
forest.py update

### DIFF
--- a/phylofisher/forest.py
+++ b/phylofisher/forest.py
@@ -395,8 +395,15 @@ def format_nodes(node, node_style, sus_clades, t):
 
 def parallel_susp_clades(trees):
     """Parallelizes the function suspicious_clades()"""
-    with Pool(processes=threads) as pool:
-        suspicious = list(pool.map(suspicious_clades, trees))
+    if threads > 1:
+        with Pool(processes=threads) as pool:
+            suspicious = list(pool.map(suspicious_clades, trees))
+            return suspicious
+    else:
+        suspicious = []
+        for tree in trees:
+            suspicious.append(suspicious_clades(tree))
+    
         return suspicious
 
 


### PR DESCRIPTION
updated the parallel_susp_clades function in forest.py due to an issue that arose with the multithreading on my M1 mac. The code currently does not function as is, due to a problem with the condition `if threads > 1:`. Commenting out the 'if' section and just running the 'else condition' code fixes the issue for me.