### PR TITLE
29 no output from fisherpy

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "phylofisher" %}
-{% set version = "1.1.2" %}
+{% set version = "1.1.3" %}
 
 package:
   name: "{{ name|lower }}"

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - trimal=1.4.1
     - raxml=8.2.12
     - hmmer=3.3
-    - diamond=0.9.36
+    - diamond=2.0.15
     - fasttree=2.1.10
     - blast=2.9.0
     - cd-hit=4.8.1

--- a/phylofisher/fisher.py
+++ b/phylofisher/fisher.py
@@ -30,10 +30,22 @@ def run_bash(cmd):
     '''
     p = subprocess.run(cmd, shell=True, capture_output=True) #, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     if p.returncode != 0:
-        if cmd.startswith('diamond'):
-            print(f'Error: {cmd}')  
-            print(f'stdout: {p.stdout.decode()}')
-            print(f'stderr: {p.stderr.decode()}')
+        # Print failing command
+        print('Command:')
+        print(cmd)  
+        print(2*'\n')
+
+        # Print std out
+        print('stdout:')
+        print(p.stdout.decode())
+        print(2*'\n')
+
+        # Print std err
+        print('stderr:')
+        print(p.stderr.decode())
+        
+        # Exit fisher.py
+        sys.exit(1)
 
 
 class Hit:

--- a/phylofisher/help_formatter.py
+++ b/phylofisher/help_formatter.py
@@ -3,7 +3,7 @@ import textwrap
 from datetime import date
 
 
-version = '1.1.2'
+version = '1.1.3'
 today = date.today()
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='phylofisher',
-    version='1.1.2',
+    version='1.1.3',
     packages=find_packages(),
     scripts={'phylofisher/fisher.py',
              'phylofisher/config.py',


### PR DESCRIPTION
- Adds better error handling in `fisher.py`
- Removes 'fisher completed without error' message 
- Updates diamond version from v0.9.36 to v2.0.15
- Bumps phylofisher version from v1.1.2 to 1.1.3

The problem described in the linked issue stems from a diamond v0.9.36 incompatibility with M1 Macs. 