### PR TITLE
fix typo matrix_constructor.smk

### DIFF
--- a/phylofisher/matrix_constructor.smk
+++ b/phylofisher/matrix_constructor.smk
@@ -67,7 +67,7 @@ rule divvier:
         'divvier.yaml'
     shell:
         f'''
-        divvier -minicol 4 -partial -divvygap {{input}} >{{log}} 2>{{log}}
+        divvier -mincol 4 -partial -divvygap {{input}} >{{log}} 2>{{log}}
 
         mv {out_dir}/mafft/{{wildcards.gene}}.aln.partial.fas {out_dir}/divvier >{{log}} 2>{{log}}
         mv {out_dir}/mafft/{{wildcards.gene}}.aln.PP {out_dir}/divvier >{{log}} 2>{{log}}


### PR DESCRIPTION
Hey! I found this typo in the divvier command, fixed it. I checked and divvier works even if it is mispelled but it does not actually use the argument.

Thanks for the amazing tool!