### PR TITLE
Fix the bug in issue#120 "NameError: name 'metadata' is not defined"

### DIFF
--- a/parasorter/forest_local.py
+++ b/parasorter/forest_local.py
@@ -9,7 +9,7 @@ from multiprocessing import Pool
 from pathlib import Path
 import argparse
 from datetime import date
-import PyQt5
+
 import matplotlib.pyplot as plt
 from Bio import SeqIO
 from ete3 import Tree, TreeStyle, NodeStyle, TextFace

--- a/parasorter/forest_local.py
+++ b/parasorter/forest_local.py
@@ -9,7 +9,7 @@ from multiprocessing import Pool
 from pathlib import Path
 import argparse
 from datetime import date
-
+import PyQt5
 import matplotlib.pyplot as plt
 from Bio import SeqIO
 from ete3 import Tree, TreeStyle, NodeStyle, TextFace
@@ -497,11 +497,6 @@ def format_nodes(node, node_style, sus_clades, t):
     return supp, sus_clades
 
 
-def parallel_susp_clades(trees):
-    """Parallelizes the function suspicious_clades()"""
-    with Pool(processes=threads) as pool:
-        suspicious = list(pool.map(suspicious_clades, trees))
-        return suspicious
 
 
 def nonredundant(result_clades):
@@ -675,13 +670,19 @@ if __name__ == '__main__':
         os.mkdir(output_folder)
 
     trees = glob.glob(f"{trees_folder}/*.raxml.support")
+    trees = [os.path.normpath(path).replace('\\', '/') for path in trees]
 
     number_of_genes = len(trees)
     metadata, tax_col = parse_metadata(args.metadata, args.input_metadata)
     threads = args.threads
+    suspicious = []
 
     if not args.backpropagate:
-        suspicious = parallel_susp_clades(trees)
+#        suspicious = parallel_susp_clades(trees)
+        for tree in trees:
+            suspicious.append(suspicious_clades(tree))
+        print(suspicious)
+
         suspicious = sorted(suspicious)
 
         make_txt = False

--- a/phylofisher/matrix_constructor.py
+++ b/phylofisher/matrix_constructor.py
@@ -46,9 +46,14 @@ def make_config():
 
 
 def get_output_files():
+    # Accepted out formats with respective suffix
+    out_dict = {'fasta':          'fas',
+                'phylip':         'phy',
+                'phylip-relaxed': 'phy',
+                'nexus':          'nex'}
 
     ret = [
-        f'{args.output}/matrix.fas',
+        f'{args.output}/matrix.{out_dict[args.out_format]}',
         f'{args.output}/indices.tsv',
         f'{args.output}/matrix_constructor_stats.tsv',
         f'{args.output}/occupancy.tsv',


### PR DESCRIPTION
Simply remove the multiprocessing module and use "for loop" to receive data in suspicious trees. 
This is usable but may slow down the  process in handling big data. 
It will be better if someone fix the bug inside the multiprocessing module, which caused the NameError in suspicious_clades. 
I fix it this way just because I'm not familiar to multiprocessing. 